### PR TITLE
Fix confluence baseURL

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -93,6 +93,16 @@ func (c *Config) SetAuthHeader(r *http.Request) error {
 	return nil
 }
 
+// Path returns the path of the request.
+// Normalise the base url as confluence requests include a /wiki
+func (c *Config) Path(req *http.Request) string {
+	url := *req.URL
+	url.RawQuery = ""
+	return strings.TrimPrefix(url.String(), c.BaseURL)
+	path := req.URL.Path
+	return path
+}
+
 // QSH returns the query string hash for this request
 // https://developer.atlassian.com/cloud/bitbucket/query-string-hash/
 func (c *Config) QSH(req *http.Request) string {
@@ -100,7 +110,7 @@ func (c *Config) QSH(req *http.Request) string {
 	method := strings.ToUpper(req.Method)
 
 	// Path can not contain &
-	path := strings.Replace(req.URL.Path, "&", "%26", -1)
+	path := strings.Replace(c.Path(req), "&", "%26", -1)
 	params := encodeQuery(req.URL.Query())
 
 	// Join method, path and params with &

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -13,6 +13,7 @@ var qshTestData = []struct {
 	summary   string
 	method    string
 	url       string
+	baseurl   string
 	canonical string
 	qsh       string
 }{
@@ -20,6 +21,7 @@ var qshTestData = []struct {
 		"No path",
 		"GET",
 		"http://example.com/",
+		"http://example.com",
 		"GET&/&",
 		"c88caad15a1c1a900b8ac08aa9686f4e8184539bea1deda36e2f649430df3239",
 	},
@@ -27,6 +29,7 @@ var qshTestData = []struct {
 		"Simple path",
 		"GET",
 		"http://example.com/something",
+		"http://example.com",
 		"GET&/something&",
 		"90b8cc6920375d6a6d133bd65be2d802a20e3544bf5704a1a80151210078798d",
 	},
@@ -34,6 +37,7 @@ var qshTestData = []struct {
 		"Simple query args",
 		"GET",
 		"http://example.com/something?simple=key",
+		"http://example.com",
 		"GET&/something&simple=key",
 		"3c1ebfedcd634a4146672368a8bee5ae364496a7fabcbda591398c00f03771d2",
 	},
@@ -41,6 +45,7 @@ var qshTestData = []struct {
 		"Simple multiple query args",
 		"GET",
 		"http://example.com/something?simple=key&another=one",
+		"http://example.com",
 		"GET&/something&another=one&simple=key",
 		"fc039e8c582c0ee90af182a3d29f37ecf1cb368f37b73d5fbd6c5bb66482dda9",
 	},
@@ -48,6 +53,7 @@ var qshTestData = []struct {
 		"Simple post",
 		"POST",
 		"http://example.com/something?simple=key",
+		"http://example.com",
 		"POST&/something&simple=key",
 		"eafb48e8c78a5b09bc2ce7b0b86289ee4a7bd58179e47006d0141b33d5165af7",
 	},
@@ -55,6 +61,7 @@ var qshTestData = []struct {
 		"JWT on query arg",
 		"GET",
 		"http://example.com/something?jwt=ABC.DEF.GHI",
+		"http://example.com",
 		"GET&/something&",
 		"90b8cc6920375d6a6d133bd65be2d802a20e3544bf5704a1a80151210078798d",
 	},
@@ -62,6 +69,7 @@ var qshTestData = []struct {
 		"Spaces in the query key",
 		"GET",
 		"http://example.com/something?some+spaces+in+this+parameter=yes",
+		"http://example.com",
 		"GET&/something&some%20spaces%20in%20this%20parameter=yes",
 		"f73fed24415974607a19ddf9af6f862d9da572ed71bbeb15ae2c64c3aec95317",
 	},
@@ -69,6 +77,7 @@ var qshTestData = []struct {
 		"Non alpha in the query key",
 		"GET",
 		"http://example.com/something?connect*=yes",
+		"http://example.com",
 		"GET&/something&connect%2A=yes",
 		"4ce3c840740a86e20beafc1d50b106996eaa844de89e879e85c92398cbfb131d",
 	},
@@ -76,6 +85,7 @@ var qshTestData = []struct {
 		"Spaces in the query value",
 		"GET",
 		"http://example.com/something?param=some+spaces+in+this+parameter",
+		"http://example.com",
 		"GET&/something&param=some%20spaces%20in%20this%20parameter",
 		"c87337655140619583bdaa6f4cc8e67ccd1abba1c1847a67d4dc0cd817e9e38a",
 	},
@@ -83,6 +93,7 @@ var qshTestData = []struct {
 		"Non alpha in the query value",
 		"GET",
 		"http://example.com/something?param=connect*",
+		"http://example.com",
 		"GET&/something&param=connect%2A",
 		"bff97fd3522d20e35e17076bf8b586924d60c1968ecaca7e6edf5fcbdb53c444",
 	},
@@ -90,6 +101,7 @@ var qshTestData = []struct {
 		"Upcase encoding",
 		"GET",
 		"http://example.com/something?director=%e5%ae%ae%e5%b4%8e%20%e9%a7%bf",
+		"http://example.com",
 		"GET&/something&director=%E5%AE%AE%E5%B4%8E%20%E9%A7%BF",
 		"459b64741b7a3f0c1fe713a4b796f3a1210402729598179b016fd97aec00b4a8",
 	},
@@ -97,6 +109,7 @@ var qshTestData = []struct {
 		"Sort parameter keys",
 		"GET",
 		"http://example.com/something?a10=1&a1=2&b1=3&b10=4",
+		"http://example.com",
 		"GET&/something&a1=2&a10=1&b1=3&b10=4",
 		"31e1a2db664e96b08862145f45e290f4045fa894886afbb020e64437dabab07e",
 	},
@@ -104,6 +117,7 @@ var qshTestData = []struct {
 		"Combine repeated parameters",
 		"GET",
 		"http://example.com/something?tuples=1%2C2%2C3&tuples=6%2C5%2C4&tuples=7%2C9%2C8",
+		"http://example.com",
 		"GET&/something&tuples=1%2C2%2C3,6%2C5%2C4,7%2C9%2C8",
 		"4f6da3fce3772b2b1958f7b97f9f7e8e0919ffc777bb74a892418faedf2fe15b",
 	},
@@ -111,20 +125,39 @@ var qshTestData = []struct {
 		"Combine repeated, unsorted parameters",
 		"GET",
 		"http://example.com/something?ids=-1&ids=1&ids=20&ids=2&ids=10",
+		"http://example.com",
 		"GET&/something&ids=-1,1,10,2,20",
 		"cfb9607f936f9523743b25897bd3a4ae822536fd18678b984b9dc0b31bfd8c46",
+	},
+	{
+		"with base url",
+		"GET",
+		"https://example.com/wiki/rest/api/search?cql=title~%22%2A%22+and+type%3Dpage&limit=10",
+		"https://example.com/wiki",
+		"GET&/rest/api/search&cql=title~%22%2A%22+and+type%3Dpage&limit=10",
+		"eb04d45dfbeafaa61923d8ac24b849b593a0c4b82c6f42c0aa0c8546dee33500",
 	},
 }
 
 // TestQSH is all according to https://developer.atlassian.com/cloud/bitbucket/query-string-hash/
 func TestQSH(t *testing.T) {
-	dummy := &Config{}
 	for _, data := range qshTestData {
+		dummy := &Config{BaseURL: data.baseurl}
 		req := httptest.NewRequest(data.method, data.url, nil)
 		qsh := dummy.QSH(req)
 		if data.qsh != qsh {
 			t.Errorf("QSH error [%s], expected %s, got %s", data.summary, data.qsh, qsh)
 		}
+	}
+}
+
+func TestPath(t *testing.T) {
+	config := Config{BaseURL: "https://example.com/wiki"}
+	req := httptest.NewRequest("GET", "https://example.com/wiki/rest/api/search?cql=title~%22%2A%22+and+type%3Dpage&limit=10", nil)
+	path := config.Path(req)
+	expectedPath := "/rest/api/search"
+	if path != expectedPath {
+		t.Errorf("Expected %s, got %s", expectedPath, path)
 	}
 }
 


### PR DESCRIPTION
This should fix the URL for confluence links, as they have a `/wiki/`